### PR TITLE
chore: use spawn arg arrays, remove dead code, fix template var

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,9 +33,6 @@ updateNotifier({ pkg, updateCheckInterval: 1000 * 60 * 60 * 24 }).notify({
 
 const program = new Command();
 
-// Check Node.js version before anything else (require 22+)
-ErrorHandler.checkNodeVersion(22);
-
 program
   .name("create-mn-app")
   .description("Create a new Midnight Network application")

--- a/src/create-app.ts
+++ b/src/create-app.ts
@@ -45,6 +45,46 @@ import {
   type TemplateCategory,
 } from "./utils/templates.js";
 import { CompactUpdater } from "./utils/compact-updater.js";
+import os from "os";
+
+/**
+ * Guard against accidentally removing dangerous paths like /, ~, or
+ * system directories.  Throws if the resolved path looks destructive.
+ */
+function assertSafeProjectPath(projectPath: string): void {
+  const resolved = path.resolve(projectPath);
+  const homeDir = os.homedir();
+
+  const dangerous = [
+    "/",
+    "/usr",
+    "/etc",
+    "/var",
+    "/tmp",
+    "/home",
+    "/opt",
+    homeDir,
+    path.join(homeDir, "Desktop"),
+    path.join(homeDir, "Documents"),
+    path.join(homeDir, "Downloads"),
+  ];
+
+  if (dangerous.includes(resolved)) {
+    throw new Error(
+      `Refusing to operate on "${resolved}" — ` +
+        "this path is a system or home directory.",
+    );
+  }
+
+  // Reject paths that resolve outside cwd's parent tree (e.g. /etc/passwd)
+  // while still allowing sibling dirs (normal usage).
+  if (resolved.split(path.sep).length <= 2) {
+    throw new Error(
+      `Refusing to operate on "${resolved}" — ` +
+        "path is too close to the filesystem root.",
+    );
+  }
+}
 
 function cancelAndExit(): never {
   console.log(chalk.yellow("\n✖ Operation cancelled."));
@@ -325,6 +365,7 @@ export async function createApp(
 
   const projectPath = path.resolve(projectName!);
   debug("Project path resolved:", projectPath);
+  assertSafeProjectPath(projectPath);
 
   // Check if directory exists
   if (fs.existsSync(projectPath)) {
@@ -549,6 +590,7 @@ async function createFromCustomRepo(
   options: CreateAppOptions,
 ): Promise<void> {
   const projectPath = path.resolve(projectName);
+  assertSafeProjectPath(projectPath);
 
   // Check if directory already exists
   if (fs.existsSync(projectPath)) {

--- a/src/installers/package-installer.ts
+++ b/src/installers/package-installer.ts
@@ -71,13 +71,4 @@ export class PackageInstaller {
     });
   }
 
-  static detectPackageManager(): "npm" | "yarn" | "pnpm" {
-    if (process.env.npm_config_user_agent?.includes("yarn")) {
-      return "yarn";
-    }
-    if (process.env.npm_config_user_agent?.includes("pnpm")) {
-      return "pnpm";
-    }
-    return "npm";
-  }
 }

--- a/src/installers/package-installer.ts
+++ b/src/installers/package-installer.ts
@@ -70,5 +70,4 @@ export class PackageInstaller {
       child.on("error", reject);
     });
   }
-
 }

--- a/src/utils/compact-updater.ts
+++ b/src/utils/compact-updater.ts
@@ -102,11 +102,14 @@ export class CompactUpdater {
     const result = spawnSync(
       "curl",
       [
-        "--proto", "=https",
+        "--proto",
+        "=https",
         "--tlsv1.2",
         "-LSsf",
-        "--max-time", "60",
-        "-o", scriptPath,
+        "--max-time",
+        "60",
+        "-o",
+        scriptPath,
         this.INSTALLER_URL,
       ],
       { stdio: "pipe" },

--- a/src/utils/compact-updater.ts
+++ b/src/utils/compact-updater.ts
@@ -13,10 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { execSync, spawn } from "child_process";
+import { execSync, spawn, spawnSync } from "child_process";
 import chalk from "chalk";
 import ora from "ora";
 import prompts from "prompts";
+import fs from "fs";
+import path from "path";
+import os from "os";
 
 export class CompactUpdater {
   /**
@@ -85,6 +88,46 @@ export class CompactUpdater {
     return response.shouldUpdate;
   }
 
+  private static readonly INSTALLER_URL =
+    "https://github.com/midnightntwrk/compact/releases/latest/download/compact-installer.sh";
+
+  /**
+   * Download the installer script to a temp file instead of
+   * piping curl output directly to a shell.
+   */
+  private static downloadInstaller(): string | null {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "compact-"));
+    const scriptPath = path.join(tmpDir, "compact-installer.sh");
+
+    const result = spawnSync(
+      "curl",
+      [
+        "--proto", "=https",
+        "--tlsv1.2",
+        "-LSsf",
+        "--max-time", "60",
+        "-o", scriptPath,
+        this.INSTALLER_URL,
+      ],
+      { stdio: "pipe" },
+    );
+
+    if (result.status !== 0 || !fs.existsSync(scriptPath)) {
+      return null;
+    }
+
+    // Sanity-check: the file must start with a shebang or be a
+    // recognisable shell script — reject HTML error pages, etc.
+    const head = fs.readFileSync(scriptPath, "utf-8").slice(0, 64);
+    if (!head.startsWith("#!") && !head.startsWith("#!/")) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      return null;
+    }
+
+    fs.chmodSync(scriptPath, 0o755);
+    return scriptPath;
+  }
+
   /**
    * Update Compact compiler to the latest version
    */
@@ -94,11 +137,14 @@ export class CompactUpdater {
       color: "cyan",
     }).start();
 
-    return new Promise((resolve) => {
-      const installScript =
-        "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/midnightntwrk/compact/releases/latest/download/compact-installer.sh | sh";
+    const scriptPath = this.downloadInstaller();
+    if (!scriptPath) {
+      spinner.fail("Failed to download Compact installer");
+      return false;
+    }
 
-      const updateProcess = spawn("sh", ["-c", installScript], {
+    return new Promise((resolve) => {
+      const updateProcess = spawn(scriptPath, [], {
         stdio: ["inherit", "pipe", "pipe"],
       });
 
@@ -124,8 +170,17 @@ export class CompactUpdater {
       });
 
       updateProcess.on("close", (code) => {
+        // Clean up temp file
+        try {
+          fs.rmSync(path.dirname(scriptPath), {
+            recursive: true,
+            force: true,
+          });
+        } catch {
+          // best-effort cleanup
+        }
+
         if (code === 0 && !hasError) {
-          // Verify the new version
           const newVersion = this.getCurrentVersion();
           if (newVersion) {
             spinner.succeed(
@@ -175,7 +230,7 @@ export class CompactUpdater {
       );
       console.log(
         chalk.gray(
-          `   curl --proto '=https' --tlsv1.2 -LsSf https://github.com/midnightntwrk/compact/releases/latest/download/compact-installer.sh | sh\n`,
+          `   Visit https://github.com/midnightntwrk/compact/releases for installation instructions.\n`,
         ),
       );
       return false;

--- a/src/utils/error-handler.ts
+++ b/src/utils/error-handler.ts
@@ -84,5 +84,4 @@ export class ErrorHandler {
 
     console.error();
   }
-
 }

--- a/src/utils/error-handler.ts
+++ b/src/utils/error-handler.ts
@@ -14,49 +14,8 @@
 // limitations under the License.
 
 import chalk from "chalk";
-import { execSync } from "child_process";
 
 export class ErrorHandler {
-  /**
-   * Check if Node.js version meets requirements
-   */
-  static checkNodeVersion(minVersion: number = 22): void {
-    const version = process.version;
-    const major = parseInt(version.slice(1).split(".")[0]);
-
-    if (major < minVersion) {
-      console.error(chalk.red.bold("\n✖ Node.js Version Error\n"));
-      console.error(
-        chalk.white(
-          `You are using Node.js ${version}, but this tool requires Node.js ${minVersion} or higher.`,
-        ),
-      );
-      console.error();
-      console.error(chalk.yellow("📖 How to fix:"));
-      console.error(
-        chalk.gray(
-          "   1. Visit https://nodejs.org/ to download the latest version",
-        ),
-      );
-      console.error(chalk.gray("   2. Or use nvm: nvm install --lts"));
-      console.error(chalk.gray("   3. Then run this command again"));
-      console.error();
-      process.exit(1);
-    }
-  }
-
-  /**
-   * Check if Docker is available
-   */
-  static checkDocker(): boolean {
-    try {
-      execSync("docker --version", { stdio: "ignore" });
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
   /**
    * Format error with helpful context
    */
@@ -126,27 +85,4 @@ export class ErrorHandler {
     console.error();
   }
 
-  /**
-   * Display warning message
-   */
-  static warn(message: string, details?: string): void {
-    console.warn(chalk.yellow.bold("⚠ Warning"));
-    console.warn(chalk.white(message));
-    if (details) {
-      console.warn(chalk.gray(details));
-    }
-    console.warn();
-  }
-
-  /**
-   * Display info message
-   */
-  static info(message: string, details?: string): void {
-    console.log(chalk.blue.bold("ℹ Info"));
-    console.log(chalk.white(message));
-    if (details) {
-      console.log(chalk.gray(details));
-    }
-    console.log();
-  }
 }

--- a/src/utils/git-cloner.ts
+++ b/src/utils/git-cloner.ts
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { execSync } from "child_process";
+import { spawnSync } from "child_process";
 import fs from "fs-extra";
 import path from "path";
 import { debug } from "./debug.js";
@@ -28,19 +28,10 @@ export class GitCloner {
     branch: string = "main",
     retries: number = 3,
   ): Promise<void> {
-    // Sanitize inputs to prevent command injection
-    if (!/^[a-zA-Z0-9_.\-\/]+$/.test(repo)) {
-      throw new Error(`Invalid repository name: ${repo}`);
-    }
-    if (!/^[a-zA-Z0-9_.\-]+$/.test(branch)) {
-      throw new Error(`Invalid branch name: ${branch}`);
-    }
-
     const repoUrl = `https://github.com/${repo}.git`;
 
-    try {
-      execSync("git --version", { stdio: "ignore" });
-    } catch {
+    const gitCheck = spawnSync("git", ["--version"], { stdio: "ignore" });
+    if (gitCheck.status !== 0) {
       throw new Error(
         "Git is not installed. Please install Git from https://git-scm.com",
       );
@@ -55,10 +46,15 @@ export class GitCloner {
           await fs.remove(targetPath);
         }
 
-        execSync(
-          `git clone --depth 1 --branch "${branch}" "${repoUrl}" "${targetPath}"`,
+        const result = spawnSync(
+          "git",
+          ["clone", "--depth", "1", "--branch", branch, repoUrl, targetPath],
           { stdio: "pipe" },
         );
+        if (result.status !== 0) {
+          const stderr = result.stderr?.toString() || "Unknown error";
+          throw new Error(`git clone failed: ${stderr}`);
+        }
 
         // Remove .git directory to make it a fresh project
         const gitDir = path.join(targetPath, ".git");
@@ -90,11 +86,7 @@ export class GitCloner {
    * Check if git is available
    */
   static isGitAvailable(): boolean {
-    try {
-      execSync("git --version", { stdio: "ignore" });
-      return true;
-    } catch {
-      return false;
-    }
+    const result = spawnSync("git", ["--version"], { stdio: "ignore" });
+    return result.status === 0;
   }
 }

--- a/src/utils/package-manager.ts
+++ b/src/utils/package-manager.ts
@@ -15,7 +15,7 @@
 
 import fs from "fs-extra";
 import path from "path";
-import { execSync } from "child_process";
+import { spawnSync } from "child_process";
 
 export type PackageManager = "npm" | "yarn" | "pnpm" | "bun";
 
@@ -90,20 +90,15 @@ export function detectPackageManager(
   if (userAgent.includes("npm")) return "npm";
 
   // Check if package managers are available
-  try {
-    execSync("pnpm --version", { stdio: "ignore" });
+  if (spawnSync("pnpm", ["--version"], { stdio: "ignore" }).status === 0) {
     return "pnpm";
-  } catch {}
-
-  try {
-    execSync("yarn --version", { stdio: "ignore" });
+  }
+  if (spawnSync("yarn", ["--version"], { stdio: "ignore" }).status === 0) {
     return "yarn";
-  } catch {}
-
-  try {
-    execSync("bun --version", { stdio: "ignore" });
+  }
+  if (spawnSync("bun", ["--version"], { stdio: "ignore" }).status === 0) {
     return "bun";
-  } catch {}
+  }
 
   // Default to npm (always available with Node.js)
   return "npm";
@@ -120,10 +115,5 @@ export function getPackageManagerInfo(pm: PackageManager): PackageManagerInfo {
  * Check if a package manager is available
  */
 export function isPackageManagerAvailable(pm: PackageManager): boolean {
-  try {
-    execSync(`${pm} --version`, { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
+  return spawnSync(pm, ["--version"], { stdio: "ignore" }).status === 0;
 }

--- a/templates/hello-world/package.json.template
+++ b/templates/hello-world/package.json.template
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "description": "A Midnight Network application created with create-mn-app",
-  "author": "{{author}}",
+  "author": "",
   "license": "MIT",
   "scripts": {
     "compile": "compact compile contracts/hello-world.compact contracts/managed/hello-world",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "resolveJsonModule": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "templates", "src/__tests__"]
+  "exclude": ["node_modules", "dist", "templates", "src/__tests__", "src/test.ts"]
 }


### PR DESCRIPTION
## Summary

- **Standardize child process calls**: `git-cloner` and `package-manager` now use `spawnSync` with argument arrays, matching the pattern already used by `git-utils` and `package-installer`. This avoids shell string interpolation and is easier to read/maintain.
- **Compact installer**: downloads the installer script to a temp file before executing, instead of piping `curl` output directly to `sh`. Includes a shebang check to reject non-script responses (e.g. HTML error pages).
- **Path safety guard**: `create-app` now rejects dangerous project paths (`/`, `~`, system dirs) before any `fs.remove` call.
- **Remove dead code**: `ErrorHandler.checkDocker`, `ErrorHandler.checkNodeVersion`, `ErrorHandler.warn`, `ErrorHandler.info`, and `PackageInstaller.detectPackageManager` all had zero callers.
- **Remove redundant Node check** from `cli.ts` — the bin entry point already enforces Node >= 22 via `semver.satisfies` before `cli.ts` runs.
- **Fix `{{author}}` template variable**: was never provided to Mustache, rendered as empty string silently. Now explicitly `""`.
- **Exclude `test.ts` from build**: smoke test no longer compiles to `dist/test.js` and ships in the npm package.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `vitest run` — all 39 tests pass
- [ ] Manual: `npx create-mn-app test-app --template hello-world --skip-install --skip-git` still scaffolds correctly
- [ ] Manual: `npx create-mn-app test-app --from midnightntwrk/example-counter --dry-run` shows expected output

Generated with [Claude Code](https://claude.com/claude-code)