### PR TITLE
fix: stop exposing wallet seed in stdout and deployment.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.26] - 2026-03-24
+
+### Changed
+
+- **Standardize child process calls** — `git-cloner` and `package-manager` now use `spawnSync` with argument arrays instead of shell string interpolation
+- **Compact installer** — downloads installer script to a temp file with shebang validation before executing, instead of piping `curl` directly to `sh`
+- **Path safety guard** — rejects dangerous project paths (`/`, `~`, system dirs) before any `fs.remove` call
+- **Remove dead code** — `ErrorHandler.checkDocker`, `checkNodeVersion`, `warn`, `info`, and `PackageInstaller.detectPackageManager` removed (zero callers)
+- **Fix `{{author}}` template variable** — was never provided to Mustache, now explicitly set to `""`
+- **Exclude `test.ts` from build** — smoke test no longer ships in npm package
+
 ## [0.3.25] - 2026-03-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.25] - 2026-03-24
+
+### Fixed
+
+- **Counter DApp build steps** — chained `compact` and `build` into a single command so the contract build can't be accidentally skipped (#25)
+- **Compact compiler version warning** — requirements check now warns when the installed compiler is newer than the template expects, which can cause `compact-runtime` version conflicts
+
 ## [0.3.24] - 2026-03-24
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.24] - 2026-03-24
+
+### Security
+
+- **Seed no longer printed to stdout** — `console.log` of wallet seed removed from deploy script; seed is now written to `.midnight-seed` file with `chmod 600` permissions
+- **Seed removed from `deployment.json`** — deployment metadata no longer contains the wallet seed; only contract address and network info are persisted
+- **`.midnight-seed` added to `.gitignore` template** — prevents accidental commit of seed file from project creation
+
+### Changed
+
+- `cli.ts` and `check-balance.ts` now read seed from `.midnight-seed` file instead of `deployment.json`
+
 ## [0.3.22] - 2026-03-18
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-mn-app",
-  "version": "0.3.24",
+  "version": "0.3.25",
   "description": "Create Midnight Network applications with zero configuration",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-mn-app",
-  "version": "0.3.25",
+  "version": "0.3.26",
   "description": "Create Midnight Network applications with zero configuration",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-mn-app",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "description": "Create Midnight Network applications with zero configuration",
   "main": "dist/index.js",
   "bin": {

--- a/src/utils/requirement-checker.ts
+++ b/src/utils/requirement-checker.ts
@@ -21,6 +21,7 @@ export interface RequirementCheck {
   required: boolean;
   found: boolean;
   version?: string;
+  warning?: string;
   installUrl?: string;
   installCommand?: string;
 }
@@ -83,11 +84,15 @@ export class RequirementChecker {
       // Check version compatibility
       let isCompatible = true;
       let versionWarning = "";
+      let warning: string | undefined;
 
       if (minVersion && currentVersion) {
-        isCompatible = this.compareVersions(currentVersion, minVersion) >= 0;
-        if (!isCompatible) {
+        const cmp = this.compareVersions(currentVersion, minVersion);
+        if (cmp < 0) {
+          isCompatible = false;
           versionWarning = ` (requires ${minVersion}+, found ${currentVersion})`;
+        } else if (cmp > 0) {
+          warning = `Compact compiler ${currentVersion} is newer than this template expects (${minVersion}). This may cause compact-runtime version conflicts. If you see build errors, install compiler version ${minVersion}.`;
         }
       }
 
@@ -96,6 +101,7 @@ export class RequirementChecker {
         required: true,
         found: isCompatible,
         version: currentVersion,
+        warning,
         installCommand:
           "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/midnightntwrk/compact/releases/latest/download/compact-installer.sh | sh",
       };
@@ -136,17 +142,30 @@ export class RequirementChecker {
     console.log(chalk.bold("[" + chalk.cyan("✓") + "] Requirements Check\n"));
 
     let allPassed = true;
+    const warnings: string[] = [];
 
     for (const check of checks) {
       const name = check.name.toLowerCase().padEnd(16);
       if (check.found) {
         const version = check.version ? chalk.gray(`${check.version}`) : "";
-        const status = chalk.green("[installed]");
+        const status = check.warning
+          ? chalk.yellow("[installed]")
+          : chalk.green("[installed]");
         console.log(`    ${chalk.gray(name)} ${version} ${status}`);
+        if (check.warning) {
+          warnings.push(check.warning);
+        }
       } else {
         allPassed = false;
         const status = chalk.red("[missing]");
         console.log(`    ${chalk.gray(name)} ${status}`);
+      }
+    }
+
+    if (warnings.length > 0) {
+      console.log();
+      for (const warning of warnings) {
+        console.log(`    ${chalk.yellow("⚠")} ${chalk.yellow(warning)}`);
       }
     }
 

--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -89,8 +89,7 @@ export const templates: Template[] = [
         commands: [
           "cd {{projectName}}",
           "{{installCmd}}",
-          "cd contract && {{runCmd}} compact",
-          "{{runCmd}} build",
+          "cd contract && {{runCmd}} compact && {{runCmd}} build",
           "cd ../counter-cli && {{runCmd}} build",
         ],
         note: "downloads ~500MB zk parameters on first run",

--- a/templates/hello-world/_gitignore
+++ b/templates/hello-world/_gitignore
@@ -21,6 +21,9 @@ contracts/managed/
 # Deployment info
 deployment.json
 
+# Wallet seed (sensitive)
+.midnight-seed
+
 # OS generated files
 .DS_Store
 Thumbs.db

--- a/templates/hello-world/src/check-balance.ts.template
+++ b/templates/hello-world/src/check-balance.ts.template
@@ -89,14 +89,15 @@ async function main() {
 
   const deployment = JSON.parse(fs.readFileSync('deployment.json', 'utf-8'));
 
-  if (!deployment.seed) {
-    console.error('❌ No wallet seed in deployment.json\n');
+  if (!fs.existsSync('.midnight-seed')) {
+    console.error('❌ No .midnight-seed file found! Run: npm run deploy\n');
     process.exit(1);
   }
+  const seed = fs.readFileSync('.midnight-seed', 'utf-8').trim();
 
   try {
     console.log('  Building wallet...');
-    const { wallet, unshieldedKeystore } = await createWallet(deployment.seed);
+    const { wallet, unshieldedKeystore } = await createWallet(seed);
 
     console.log('  Syncing with network...');
     const state = await Rx.firstValueFrom(

--- a/templates/hello-world/src/cli.ts.template
+++ b/templates/hello-world/src/cli.ts.template
@@ -176,8 +176,14 @@ async function main() {
 
   try {
     // Create wallet from saved seed
+    if (!fs.existsSync('.midnight-seed')) {
+      console.error('❌ No .midnight-seed file found! Run: npm run deploy\n');
+      process.exit(1);
+    }
+    const seed = fs.readFileSync('.midnight-seed', 'utf-8').trim();
+
     console.log('  Connecting to wallet...');
-    const walletCtx = await createWallet(deployment.seed);
+    const walletCtx = await createWallet(seed);
 
     console.log('  Syncing with network...');
     const state = await Rx.firstValueFrom(walletCtx.wallet.state().pipe(Rx.throttleTime(5000), Rx.filter((s) => s.isSynced)));

--- a/templates/hello-world/src/deploy.ts.template
+++ b/templates/hello-world/src/deploy.ts.template
@@ -196,14 +196,21 @@ async function main() {
   const rl = createInterface({ input: stdin, output: stdout });
 
   try {
-    // Check for existing deployment.json (previous attempt or completed deployment)
+    // Check for existing deployment and seed
     let existingSeed: string | undefined;
     let existingContract: string | undefined;
+
+    if (fs.existsSync('.midnight-seed')) {
+      try {
+        existingSeed = fs.readFileSync('.midnight-seed', 'utf-8').trim();
+      } catch {
+        // Ignore read errors
+      }
+    }
 
     if (fs.existsSync('deployment.json')) {
       try {
         const existing = JSON.parse(fs.readFileSync('deployment.json', 'utf-8'));
-        if (existing.seed) existingSeed = existing.seed;
         if (existing.contractAddress) existingContract = existing.contractAddress;
       } catch {
         // Ignore parse errors
@@ -241,7 +248,10 @@ async function main() {
           : toHex(Buffer.from(generateRandomSeed()));
 
         if (choice.trim() !== '2') {
-          console.log(`\n  ⚠️  SAVE THIS SEED (you'll need it later):\n  ${seed}\n`);
+          fs.writeFileSync('.midnight-seed', seed, { mode: 0o600 });
+          console.log('\n  ⚠️  A new wallet seed has been generated.');
+          console.log('  It has been saved to .midnight-seed (chmod 600).');
+          console.log('  Back it up securely and never commit this file.\n');
         }
       }
     } else {
@@ -251,7 +261,10 @@ async function main() {
         : toHex(Buffer.from(generateRandomSeed()));
 
       if (choice.trim() !== '2') {
-        console.log(`\n  ⚠️  SAVE THIS SEED (you'll need it later):\n  ${seed}\n`);
+        fs.writeFileSync('.midnight-seed', seed, { mode: 0o600 });
+        console.log('\n  ⚠️  A new wallet seed has been generated.');
+        console.log('  It has been saved to .midnight-seed (chmod 600).');
+        console.log('  Back it up securely and never commit this file.\n');
       }
     }
 
@@ -325,9 +338,10 @@ async function main() {
       console.log('  └──────────────────────────────────────────────────────────────┘\n');
 
       // Save seed for retry
-      const partialInfo = { seed, address, network: 'preprod', status: 'proof_server_unavailable' };
+      fs.writeFileSync('.midnight-seed', seed, { mode: 0o600 });
+      const partialInfo = { address, network: 'preprod', status: 'proof_server_unavailable' };
       fs.writeFileSync('deployment.json', JSON.stringify(partialInfo, null, 2));
-      console.log('  Wallet saved to deployment.json\n');
+      console.log('  Wallet saved to .midnight-seed and deployment.json\n');
 
       await walletCtx.wallet.stop();
       process.exit(1);
@@ -371,9 +385,10 @@ async function main() {
           console.log('  │                                                              │');
           console.log('  └──────────────────────────────────────────────────────────────┘\n');
 
-          const partialInfo = { seed, address, network: 'preprod', status: 'proof_server_error' };
+          fs.writeFileSync('.midnight-seed', seed, { mode: 0o600 });
+          const partialInfo = { address, network: 'preprod', status: 'proof_server_error' };
           fs.writeFileSync('deployment.json', JSON.stringify(partialInfo, null, 2));
-          console.log('  Wallet saved to deployment.json\n');
+          console.log('  Wallet saved to .midnight-seed and deployment.json\n');
 
           await walletCtx.wallet.stop();
           process.exit(1);
@@ -414,15 +429,15 @@ async function main() {
             console.log('  └───────────────────────────────────────────────────────────┘\n');
 
             // Save partial deployment info so user can resume
+            fs.writeFileSync('.midnight-seed', seed, { mode: 0o600 });
             const partialInfo = {
-              seed,
               address,
               network: 'preprod',
               status: 'pending_dust',
               lastAttempt: new Date().toISOString(),
             };
             fs.writeFileSync('deployment.json', JSON.stringify(partialInfo, null, 2));
-            console.log('  Wallet saved to deployment.json\n');
+            console.log('  Wallet saved to .midnight-seed and deployment.json\n');
 
             await walletCtx.wallet.stop();
             process.exit(1);
@@ -443,9 +458,9 @@ async function main() {
     console.log(`  Contract Address: ${contractAddress}\n`);
 
     // 5. Save deployment info
+    fs.writeFileSync('.midnight-seed', seed, { mode: 0o600 });
     const deploymentInfo = {
       contractAddress,
-      seed,
       network: 'preprod',
       deployedAt: new Date().toISOString(),
     };


### PR DESCRIPTION
## Summary
- Seed was being printed to terminal via `console.log` and stored in `deployment.json` — both unnecessary exposure vectors (stdout captured by CI/CD logs, deployment.json could be shared/committed)
- Seed now written to `.midnight-seed` file with `chmod 600` instead of printed to stdout
- Removed `seed` field from all `deployment.json` writes — it only stores contract address and network metadata now
- `cli.ts` and `check-balance.ts` read seed from `.midnight-seed` instead of `deployment.json`
- Added `.midnight-seed` to `.gitignore` template

Fixes: #25 too

## Test plan
- [x] Run `npm run deploy` with option 1 (create new wallet) — verify seed is NOT printed to terminal
- [ ] Verify `.midnight-seed` file is created with correct permissions (`ls -la .midnight-seed`)
- [ ] Verify `deployment.json` does NOT contain a `seed` field after deploy
- [ ] Run `npm run cli` — verify it reads seed from `.midnight-seed` and connects successfully
- [ ] Run `npm run check-balance` — verify it reads seed from `.midnight-seed`
- [ ] Run deploy with proof server down — verify retry saves seed to `.midnight-seed`, not `deployment.json`
- [ ] Delete `.midnight-seed` and run `npm run cli` — verify clear error message