### PR TITLE
Add network sync progress feedback to hello-world templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-mn-app",
-  "version": "0.3.27",
+  "version": "0.3.28",
   "description": "Create Midnight Network applications with zero configuration",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-mn-app",
-  "version": "0.3.26",
+  "version": "0.3.27",
   "description": "Create Midnight Network applications with zero configuration",
   "main": "dist/index.js",
   "bin": {

--- a/templates/hello-world/src/check-balance.ts.template
+++ b/templates/hello-world/src/check-balance.ts.template
@@ -97,7 +97,16 @@ async function main() {
     const { wallet, unshieldedKeystore } = await createWallet(seed);
 
     console.log('  Syncing with network...');
+    console.log('  ℹ  This may take several minutes depending on network size.');
+    console.log('     RPC disconnection messages during sync are normal and can be safely ignored.\n');
+    const syncStart = Date.now();
+    const syncInterval = setInterval(() => {
+      const elapsed = Math.round((Date.now() - syncStart) / 1000);
+      process.stdout.write(`\r  ⏳ Still syncing... (${elapsed}s elapsed)   `);
+    }, 5000);
     const state = await wallet.waitForSyncedState();
+    clearInterval(syncInterval);
+    process.stdout.write('\r  ✓ Synced with network.                                      \n');
 
     const address = unshieldedKeystore.getBech32Address();
     const tNightBalance = state.unshielded.balances[unshieldedToken().raw] ?? 0n;

--- a/templates/hello-world/src/cli.ts.template
+++ b/templates/hello-world/src/cli.ts.template
@@ -169,7 +169,16 @@ async function main() {
     const walletCtx = await createWallet(seed);
 
     console.log('  Syncing with network...');
+    console.log('  ℹ  This may take several minutes depending on network size.');
+    console.log('     RPC disconnection messages during sync are normal and can be safely ignored.\n');
+    const syncStart = Date.now();
+    const syncInterval = setInterval(() => {
+      const elapsed = Math.round((Date.now() - syncStart) / 1000);
+      process.stdout.write(`\r  ⏳ Still syncing... (${elapsed}s elapsed)   `);
+    }, 5000);
     const state = await walletCtx.wallet.waitForSyncedState();
+    clearInterval(syncInterval);
+    process.stdout.write('\r  ✓ Synced with network.                                      \n');
     const balance = state.unshielded.balances[unshieldedToken().raw] ?? 0n;
     console.log(`  Balance: ${balance.toLocaleString()} tNight\n`);
 

--- a/templates/hello-world/src/deploy.ts.template
+++ b/templates/hello-world/src/deploy.ts.template
@@ -255,7 +255,16 @@ async function main() {
     const walletCtx = await createWallet(seed.trim());
 
     console.log('  Syncing with network...');
+    console.log('  ℹ  This may take several minutes depending on network size.');
+    console.log('     RPC disconnection messages during sync are normal and can be safely ignored.\n');
+    const syncStart = Date.now();
+    const syncInterval = setInterval(() => {
+      const elapsed = Math.round((Date.now() - syncStart) / 1000);
+      process.stdout.write(`\r  ⏳ Still syncing... (${elapsed}s elapsed)   `);
+    }, 5000);
     const state = await walletCtx.wallet.waitForSyncedState();
+    clearInterval(syncInterval);
+    process.stdout.write('\r  ✓ Synced with network.                                      \n');
     const address = walletCtx.unshieldedKeystore.getBech32Address();
     const balance = state.unshielded.balances[unshieldedToken().raw] ?? 0n;
 


### PR DESCRIPTION
## Summary
- Adds informational messaging during wallet sync explaining it may take several minutes depending on network size
- Adds a live elapsed-time counter so users know the process is still active
- Notes that RPC disconnection log messages are expected and can be safely ignored

Closes #32

## Test plan
- [x] `npm run build` passes
- [x] All 39 tests pass (`npm test`)
- [x] Scaffolded a test app and verified templates render with new sync feedback
- [ ] Manual verification on preprod with `npm run setup` / `npm run deploy`