### PR TITLE
fix(hello-world): bump proof-server to 8.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **hello-world proof-server version mismatch** — bumped `midnightntwrk/proof-server` from `7.0.0` to `8.0.3` in `templates/hello-world/docker-compose.yml.template` to align with the ledger-v8 (`8.0.3`) runtime already pinned in `package.json.template`. Prevents "ProofPreimageVersioned" / "Unknown discriminant 109" errors at deploy time. Partial fix for #34.
+
 ## [0.3.26] - 2026-03-24
 
 ### Changed

--- a/templates/hello-world/docker-compose.yml.template
+++ b/templates/hello-world/docker-compose.yml.template
@@ -1,6 +1,6 @@
 services:
   proof-server:
-    image: midnightntwrk/proof-server:7.0.0
+    image: midnightntwrk/proof-server:8.0.3
     platform: linux/amd64
     environment:
       - PORT=6300


### PR DESCRIPTION
## Description

The hello-world template pins `@midnight-ntwrk/ledger-v8@8.0.3` but the compose file still runs `proof-server:7.0.0`. That mismatch makes `npm run deploy` fail with version errors on a freshly scaffolded project. This PR bumps the image tag to match.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Related to #34 (partial fix — the "Next Steps" strings and counter/bboard templates will be addressed separately).

## Motivation and Context

A first-time user running `npx create-mn-app my-app -t hello-world` and then `npm run setup` hits an immediate deploy failure because the proof-server version no longer matches ledger-v8. Aligning the compose image with the SDK version already pinned in `package.json.template` fixes it.

## Changes Made

- `templates/hello-world/docker-compose.yml.template` — bump `midnightntwrk/proof-server` from `7.0.0` to `8.0.3`.
- `CHANGELOG.md` — entry under `[Unreleased]`.

## Testing Performed

### Manual Testing

- [x] Tested on macOS
- [ ] Tested on Linux
- [ ] Tested on Windows
- [x] Tested with npm

### Test Commands

```bash
npm run lint
npm run format:check
npm run build
npm test

npm link
create-mn-app /tmp/mn-smoke -t hello-world --use-npm -y --skip-install --skip-git
cd /tmp/mn-smoke && docker compose up -d && curl -sf http://127.0.0.1:6300/version && docker compose down
```

### Test Results

- `npm run lint`, `format:check`, `build`, `test` — all pass (39/39).
- Scaffolded `docker-compose.yml` renders with `image: midnightntwrk/proof-server:8.0.3`.
- Container boots and `GET /version` returns HTTP 200.

## Breaking Changes

- [ ] This PR introduces breaking changes

## Documentation

- [x] CHANGELOG.md updated

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes

### Licensing

- [x] I have added SPDX license headers to any new files (no new files added)
- [ ] I have signed the Contributor License Agreement (CLA)
- [x] I have read and agree to the Code of Conduct

### Dependencies

- [x] I have checked that no unnecessary dependencies were added
- [x] package.json and package-lock.json are in sync
