### PR TITLE
fix(hello-world): wait for proof-server to be ready before deploying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **hello-world proof-server readiness** — `npm run setup` could start `npm run deploy` before the proof-server was actually listening, causing intermittent connection errors (especially on slow machines or arm64 hosts emulating linux/amd64). The proof-server image is distroless (no `curl`, no shell), which blocks a conventional healthcheck. Added a lightweight `proof-server-ready` sidecar (`curlimages/curl`) that polls `/version` and reports `healthy`, and switched the `setup` script to `docker compose up -d --wait` so startup now blocks until the proof-server actually responds.
+
 ## [0.3.26] - 2026-03-24
 
 ### Changed

--- a/templates/hello-world/docker-compose.yml.template
+++ b/templates/hello-world/docker-compose.yml.template
@@ -7,3 +7,25 @@ services:
     ports:
       - "6300:6300"
     restart: unless-stopped
+
+  # Readiness gate for the proof-server.
+  # The proof-server image is distroless (no `curl`, no `sh`), so we cannot
+  # define a healthcheck on the proof-server container itself. Instead, this
+  # sidecar polls `/version` from a network peer and flips to `healthy` once
+  # the proof-server responds. Combined with `docker compose up --wait`, this
+  # lets `npm run setup` block until the proof-server is actually serving,
+  # avoiding a race where `npm run deploy` starts too early.
+  proof-server-ready:
+    image: curlimages/curl:8.11.1
+    depends_on:
+      - proof-server
+    command:
+      - sh
+      - -c
+      - "until curl -fs http://proof-server:6300/version; do sleep 1; done; touch /tmp/ready; sleep infinity"
+    healthcheck:
+      test: ["CMD", "test", "-f", "/tmp/ready"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+      start_period: 2s

--- a/templates/hello-world/package.json.template
+++ b/templates/hello-world/package.json.template
@@ -8,7 +8,7 @@
   "scripts": {
     "compile": "compact compile contracts/hello-world.compact contracts/managed/hello-world",
     "build": "npx tsc --noEmit || true",
-    "setup": "docker compose up -d && npm run compile && npm run deploy",
+    "setup": "docker compose up -d --wait && npm run compile && npm run deploy",
     "deploy": "npx tsx src/deploy.ts",
     "cli": "npx tsx src/cli.ts",
     "check-balance": "npx tsx src/check-balance.ts",


### PR DESCRIPTION
## Description

`npm run setup` starts `npm run deploy` as soon as the proof-server container exists, without waiting for the server to actually accept requests. On slow machines or arm64 hosts emulating linux/amd64 this races and produces connection errors.

The proof-server image is stripped down and ships without `curl` or a shell, so a healthcheck inside that container doesn't work. This PR adds a tiny sidecar that checks readiness from another container, and makes `setup` block until it reports healthy.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Related to #34 (does not close it).

## Motivation and Context

Without a readiness gate, `npm run setup` can appear to succeed while silently failing the deploy step, which is confusing for first-time users. A small helper container solves it without modifying the proof-server service.

## Changes Made

- `templates/hello-world/docker-compose.yml.template` — add a `proof-server-ready` sidecar that polls `http://proof-server:6300/version` and exposes a healthcheck once it responds.
- `templates/hello-world/package.json.template` — `setup` now runs `docker compose up -d --wait`.
- `CHANGELOG.md` — entry under `[Unreleased]`.

## Testing Performed

### Manual Testing

- [x] Tested on macOS
- [ ] Tested on Linux
- [ ] Tested on Windows
- [x] Tested with npm

### Test Commands

```bash
npm run lint
npm run format:check
npm run build
npm test

npm link
create-mn-app /tmp/mn-smoke -t hello-world --use-npm -y --skip-install --skip-git
cd /tmp/mn-smoke && docker compose up -d --wait && curl -sf http://127.0.0.1:6300/version && docker compose down
```

### Test Results

- `npm run lint`, `format:check`, `build`, `test` — all pass (39/39).
- `docker compose up -d --wait` returns exit 0 in ~8s with both services healthy.
- Immediately after `--wait` returns, `GET /version` responds with HTTP 200.

## Breaking Changes

- [ ] This PR introduces breaking changes

## Documentation

- [x] CHANGELOG.md updated

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes

### Licensing

- [x] I have added SPDX license headers to any new files (no new files added)
- [ ] I have signed the Contributor License Agreement (CLA)
- [x] I have read and agree to the Code of Conduct

### Dependencies

- [x] I have checked that no unnecessary dependencies were added
- [x] package.json and package-lock.json are in sync
