### PR TITLE
fix(template): resolve macOS quickstart deploy failures

### DIFF
--- a/templates/hello-world/docker-compose.yml.template
+++ b/templates/hello-world/docker-compose.yml.template
@@ -1,7 +1,6 @@
 services:
   proof-server:
     image: midnightntwrk/proof-server:7.0.0
-    platform: linux/amd64
     environment:
       - PORT=6300
     ports:

--- a/templates/hello-world/src/deploy.ts.template
+++ b/templates/hello-world/src/deploy.ts.template
@@ -131,7 +131,7 @@ async function createWallet(seed: string) {
 }
 
 async function createProviders(walletCtx: ReturnType<typeof createWallet> extends Promise<infer T> ? T : never) {
-  const privateStatePassword = process.env.PRIVATE_STATE_PASSWORD?.trim() || 'development';
+  const privateStatePassword = process.env.PRIVATE_STATE_PASSWORD?.trim() || 'dev!Xk9#mQ2pLw@z';
 
   const state = await walletCtx.wallet.waitForSyncedState();
 
@@ -302,8 +302,7 @@ async function main() {
           walletCtx.unshieldedKeystore.getPublicKey(),
           (payload) => walletCtx.unshieldedKeystore.signData(payload),
         );
-        const signedRecipe = await walletCtx.wallet.signRecipe(recipe, (payload) => walletCtx.unshieldedKeystore.signData(payload));
-        await walletCtx.wallet.submitTransaction(await walletCtx.wallet.finalizeRecipe(signedRecipe));
+        await walletCtx.wallet.submitTransaction(await walletCtx.wallet.finalizeRecipe(recipe));
       }
 
       console.log('  Waiting for DUST tokens...');


### PR DESCRIPTION
## Summary

Three independent issues in the `hello-world` template caused `npm run deploy` to fail on a fresh quickstart, especially on Apple Silicon macOS. All three are fixable in the template; this PR bundles them since they're tiny and tend to be hit together on the same first run.

## Issues fixed

### 1. DUST registration fails with `Custom error: 192` (`InputsSignaturesLengthMismatch`)

`wallet.registerNightUtxosForDustGeneration(...)` already accepts a `signData` callback and signs internally. The template then called `wallet.signRecipe(recipe, ...)` on the returned recipe, producing a double-signed transaction that the node rejects.

```diff
 const recipe = await walletCtx.wallet.registerNightUtxosForDustGeneration(
   nightUtxos,
   walletCtx.unshieldedKeystore.getPublicKey(),
   (payload) => walletCtx.unshieldedKeystore.signData(payload),
 );
-const signedRecipe = await walletCtx.wallet.signRecipe(recipe, (payload) => walletCtx.unshieldedKeystore.signData(payload));
-await walletCtx.wallet.submitTransaction(await walletCtx.wallet.finalizeRecipe(signedRecipe));
+await walletCtx.wallet.submitTransaction(await walletCtx.wallet.finalizeRecipe(recipe));
```

`balanceTx` still calls `signRecipe` correctly because `balanceUnboundTransaction` returns an unsigned recipe — that path is unchanged.

### 2. Proof server runs under Rosetta on Apple Silicon

`platform: linux/amd64` was hardcoded in `docker-compose.yml.template`. On M1/M2/M3 macs this forces Rosetta emulation, which makes ZK proof generation extremely slow (or hangs). `midnightntwrk/proof-server:7.0.0` publishes an arm64 image, so dropping the line lets Docker pick the native arch on Apple Silicon while still resolving correctly on amd64 hosts.

```diff
 proof-server:
   image: midnightntwrk/proof-server:7.0.0
-  platform: linux/amd64
   environment:
     - PORT=6300
```

### 3. Default private-state password fails wallet SDK policy

`'development'` is 11 chars — the wallet SDK requires ≥16 chars and rejects sequential patterns, so a fresh deploy errored out before doing anything. Bumped the default to a 16-char value that satisfies the policy.

```diff
-const privateStatePassword = process.env.PRIVATE_STATE_PASSWORD?.trim() || 'development';
+const privateStatePassword = process.env.PRIVATE_STATE_PASSWORD?.trim() || 'dev!Xk9#mQ2pLw@z';
```

## Test plan

- [x] `npm run build` (tsc) clean
- [x] `npm test` — 39/39 passing
- [ ] Generate fresh project via `create-mn-app` and run `npm run deploy` end-to-end against preprod
- [ ] Verify on Apple Silicon that proof server runs natively (`docker inspect` shows arm64)