### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-mn-app",
-  "version": "0.3.28",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-mn-app",
-      "version": "0.3.28",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-mn-app",
-  "version": "0.3.28",
+  "version": "0.4.0",
   "description": "Create Midnight Network applications with zero configuration",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary

- Bump `create-mn-app` to **0.4.0**.

PR #43 swapped the `hello-world` template's default network from preprod to a bundled local devnet and added a `--network` flag for public-network targeting. Behavior-changing feature → minor bump.

## Test plan

- [x] `npm test` — 77/77 pass
- [x] `npm run build` clean
- [x] E2E exercised manually: `npm run setup` brings up devnet, deploys, `npm run test:e2e` passes against deployed contract.
- [ ] Tag `v0.4.0` and create a GitHub release after merge → triggers `Publish to NPM` workflow.