### PR TITLE
Bump version to 0.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-mn-app",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-mn-app",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-mn-app",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Create Midnight Network applications with zero configuration",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary

- Bump \`create-mn-app\` to **0.4.1**.

PR #49 (merged into main) fixes the hello-world template's wallet re-syncing from seed on every \`deploy\` / \`cli\` / \`check-balance\` run (closes #41). The fix persists serialized wallet state under \`.midnight-wallet-state/<network>/\` and restores it on subsequent runs.

Bug fix → patch bump from 0.4.0.

## Test plan

- [x] \`npm run format:check\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm test\` — 90/90 pass
- [x] Manually validated on \`preview\` in #49 (7m fresh sync → 5s restored)
- [ ] Tag \`v0.4.1\` and create a GitHub release after merge → triggers \`Publish to NPM\` workflow.