### PR TITLE
fix(hello-world): use fileURLToPath in isMain() so `npm run network` works on Windows

### DIFF
--- a/templates/hello-world/src/network.ts
+++ b/templates/hello-world/src/network.ts
@@ -6,6 +6,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as crypto from 'node:crypto';
+import { fileURLToPath } from 'node:url';
 
 export type NetworkId = 'undeployed' | 'preview' | 'preprod';
 
@@ -277,7 +278,7 @@ function isMain(): boolean {
   // import.meta.url is a `file://` URL; argv[1] is a filesystem path.
   // Compare resolved paths to handle symlinks/aliases.
   try {
-    const here = new URL(import.meta.url).pathname;
+    const here = fileURLToPath(import.meta.url);
     const invoked = process.argv[1] && fs.realpathSync(process.argv[1]);
     return invoked === fs.realpathSync(here);
   } catch {


### PR DESCRIPTION
## What
In the `hello-world` template, `src/network.ts` computes its own module path in `isMain()` via `new URL(import.meta.url).pathname`. On Windows that returns `/C:/...` (a leading slash before the drive letter), so `fs.realpathSync(here)` throws `ENOENT`; the surrounding `try/catch` swallows it and `isMain()` returns `false`. The CLI block then never runs, so `npm run network <name>` is a silent no-op on Windows (exits 0, switches nothing, writes nothing). See #51.

## Fix
Use `fileURLToPath(import.meta.url)`, matching the convention already used in `cli.ts.template` and `deploy.ts.template`. Correct on Windows and POSIX.

## Verification
- Before (Windows, Node 24.11.1): `new URL(import.meta.url).pathname` -> `/C:/...` -> `realpathSync` throws `ENOENT` -> `isMain()` returns false -> command does nothing.
- After: `fileURLToPath(import.meta.url)` -> `C:\...` -> resolves correctly -> the CLI runs. POSIX behavior unchanged (both forms agree there).

Fixes #51.
