### PR TITLE
chore: clean dist before publish to avoid shipping stale artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "npm run clean && npm run build",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",


### PR DESCRIPTION
## Problem
`tsc` doesn't remove stale output, so a local `npm publish` can ship dead files from a prior build. The 0.4.2 release (published manually as a one-off) included `dist/test.js` and `dist/installers/wallet-generator.*` — artifacts of source files that are excluded/removed and that a fresh CI build does not produce.

## Fix
`prepublishOnly: "npm run clean && npm run build"` — every publish (CI and local) starts from a clean `dist`. Targeted at the publish boundary so it doesn't affect `build`, `dev`, or `test:smoke`.

## Verification
- `npm pack --dry-run`: tarball goes from **86 → 78 files**, no `test.js` / `wallet-generator.*`
- `npm test`: 90/90 ✓

Note: 0.4.2 on npm is unaffected (immutable); this prevents recurrence on the next release.