### PR TITLE
chore: ignore ESM-only major bumps for chalk and ora in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,14 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    ignore:
+      # chalk@5 and ora@6+ are ESM-only ("type": "module"); this package
+      # compiles to CommonJS, so major bumps break `require()` at runtime.
+      # Pin to the last CJS-compatible majors (chalk 4.x, ora 5.x).
+      - dependency-name: "chalk"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "ora"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Why
`chalk@5` and `ora@6+` are ESM-only (`"type": "module"`). This package compiles to **CommonJS**, so importing those majors breaks `require()` in the published CLI. Verified: `npm view chalk@5 type` → `module`, `npm view ora@9 type` → `module`.

## Change
Add Dependabot `ignore` rules for `version-update:semver-major` on `chalk` and `ora`, keeping them on the last CJS-compatible majors (chalk 4.x, ora 5.x). Stops Dependabot from reopening incompatible PRs (closes the loop on #16 and #22).

Adopting these would require migrating the CLI to ESM — out of scope here.