### PR TITLE
fix(package.json): replace `rm -rf` with cross-platform Node.js clean script

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:coverage": "vitest run --coverage",
     "test:smoke": "npm run build && node dist/test.js",
     "test-local": "npm run build && npm link && npx create-mn-app test-app",
-    "clean": "rm -rf dist test-app",
+    "clean": "node scripts/clean.js",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "format": "prettier --write \"src/**/*.ts\"",

--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -1,0 +1,22 @@
+// Cross-platform clean script for create-mn-app.
+// Replaces the Unix-specific `rm -rf dist test-app` command.
+// Works on Linux, macOS, and Windows without requiring a POSIX shell.
+
+const fs = require("fs");
+
+const targets = ["dist", "test-app"];
+
+for (const dir of targets) {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+    console.log(`Removed: ${dir}`);
+  } catch (err) {
+    if (err.code === "ENOENT") {
+      // Directory doesn't exist — this is fine
+      console.log(`Skipped (not found): ${dir}`);
+    } else {
+      console.error(`Failed to remove ${dir}: ${err.message}`);
+      process.exit(1);
+    }
+  }
+}


### PR DESCRIPTION
## Bug Report & Fix

Closes #79

### Problem

The `clean` npm script uses `rm -rf dist test-app`, which is a Unix-only shell command. On Windows (PowerShell / CMD / Windows Terminal), `npm run clean` fails immediately with:

```
> create-mn-app@0.4.2 clean
> rm -rf dist test-app

'rm' is not recognized as an internal or external command, operable program or batch file.
```

This blocks Windows contributors from cleaning build artifacts and breaks CI on Windows runners.

### Root Cause

The `rm` binary is not available on Windows unless the user has installed Git Bash, MSYS2, or WSL. The `create-mn-app` CLI is meant to work cross-platform (it targets Node.js >=22), but its own build scripts are not cross-platform.

### Fix

1. **Added `scripts/clean.js`** — A small Node.js utility that uses `fs.rmSync(dir, { recursive: true, force: true })`, which is fully cross-platform (Linux, macOS, Windows). It gracefully skips missing directories and exits with code 1 on actual filesystem errors.

2. **Updated `package.json`** — Changed `"clean": "rm -rf dist test-app"` to `"clean": "node scripts/clean.js"`.

### Verification

- [x] Script runs successfully on Windows (PowerShell 7.x)
- [x] Script runs successfully on Linux/macOS (same behavior as `rm -rf`)
- [x] Missing directories are skipped without error
- [x] Actual errors (permissions, etc.) exit with non-zero code
- [x] No new dependencies added — uses Node.js built-in `fs`

### Impact

This fix unblocks the `clean` workflow for Windows developers and makes the repository's npm scripts truly cross-platform, matching the CLI's own cross-platform promises.

### Related

- `engines.node` already requires `>=22.0.0`, so `fs.rmSync` (stabilized in Node.js 14.14.0) is safe.
