### PR TITLE
fix(hello-world): make clean script cross-platform (Windows rm -rf failure)

### DIFF
--- a/templates/hello-world/package.json.template
+++ b/templates/hello-world/package.json.template
@@ -15,7 +15,7 @@
     "network": "npx tsx src/network.ts",
     "proof-server:start": "docker compose up -d",
     "proof-server:stop": "docker compose down",
-    "clean": "rm -rf contracts/managed .midnight-state.json .midnight-wallet-state",
+    "clean": "node -e \"for (const p of ['contracts/managed','.midnight-state.json','.midnight-wallet-state']) require('fs').rmSync(p,{recursive:true,force:true})\"",
     "test": "echo \"Error: no test specified\" && exit 1",
     "test:e2e": "tsx scripts/e2e-check.ts"
   },


### PR DESCRIPTION
## Problem

The hello-world template's `clean` script uses the Unix-only `rm -rf`. Because this template is copied verbatim into every scaffolded project, `npm run clean` fails on native Windows for all users:

- PowerShell: `rm` is an alias for `Remove-Item`, which rejects `-rf`.
- cmd.exe: `rm` is not a recognized command.

The command errors out and nothing is removed.

## Fix

Replace `rm -rf` with a zero-dependency Node one-liner. `engines.node` is already `>=22.0.0`, so `fs.rmSync(..., { recursive: true, force: true })` is guaranteed available; it removes both files and directories and ignores missing paths, matching the previous `rm -rf` semantics.

```json
"clean": "node -e \"for (const p of ['contracts/managed','.midnight-state.json','.midnight-wallet-state']) require('fs').rmSync(p,{recursive:true,force:true})\"",
```

## Verification

- Ran the new command on Windows (PowerShell): it removes `contracts/managed`, `.midnight-state.json`, and `.midnight-wallet-state`, exits `0`, and is a clean no-op when the paths are absent — matching `rm -rf` behavior.
- The rendered template remains valid JSON. No new dependencies.

This is distinct from #79/#80, which fix the repo's own root `package.json` clean script; this PR fixes the template that ships to end users.

Closes #54.
