### PR TITLE
fix(hello-world): make wallets mnemonic-first (BIP-39) for Lace parity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "eslint": "^10.0.3",
         "eslint-config-prettier": "^10.1.8",
         "prettier": "^3.8.1",
+        "tsx": "^4.23.5",
         "typescript": "^5.0.0",
         "vitest": "^4.0.18"
       },
@@ -138,6 +139,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1876,6 +2319,48 @@
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
     },
     "node_modules/escape-goat": {
       "version": "4.0.0",
@@ -3677,6 +4162,25 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.23.5",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.5.tgz",
+      "integrity": "sha512-rw55FUaqOoI7RvlQwLbhO4nSDApnQ4/CykPuiQ/EPvtrX3WA9Ig55jIt9VvbBJbzJuj12ueRu4PMZ2SxPVbihg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-mn-app",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-mn-app",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -25,6 +25,7 @@
         "create-mn-app": "bin/create-midnight-app.js"
       },
       "devDependencies": {
+        "@scure/bip39": "2.2.0",
         "@types/cross-spawn": "^6.0.2",
         "@types/fs-extra": "^11.0.1",
         "@types/mustache": "^4.2.2",
@@ -330,6 +331,19 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -664,6 +678,30 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.2.0.tgz",
+      "integrity": "sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:smoke": "npm run build && node dist/test.js",
+    "test:smoke": "npm run build && tsx src/test.ts",
     "test-local": "npm run build && npm link && npx create-mn-app test-app",
     "clean": "rm -rf dist test-app",
     "lint": "eslint src/",
@@ -73,6 +73,7 @@
     "eslint": "^10.0.3",
     "eslint-config-prettier": "^10.1.8",
     "prettier": "^3.8.1",
+    "tsx": "^4.23.5",
     "typescript": "^5.0.0",
     "vitest": "^4.0.18"
   },

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "validate-npm-package-name": "^5.0.0"
   },
   "devDependencies": {
+    "@scure/bip39": "2.2.0",
     "@types/cross-spawn": "^6.0.2",
     "@types/fs-extra": "^11.0.1",
     "@types/mustache": "^4.2.2",

--- a/src/__tests__/network.test.ts
+++ b/src/__tests__/network.test.ts
@@ -3,15 +3,23 @@ import fs from "fs-extra";
 import path from "node:path";
 import os from "node:os";
 import { execSync } from "node:child_process";
+import { pbkdf2Sync } from "node:crypto";
 import {
   loadState,
   saveState,
   parseNetworkFlag,
   resolveNetwork,
   getOrCreateSeed,
+  getOrCreateWallet,
+  generateMnemonicPhrase,
+  isValidMnemonic,
+  mnemonicToSeedHex,
+  normalizeMnemonic,
+  formatWalletBackupNotice,
   getDeployment,
   recordDeployment,
   setActiveNetwork,
+  GENESIS_SEED,
   NETWORK_CONFIGS,
   STATE_FILE_NAME,
   STATE_VERSION,
@@ -125,6 +133,22 @@ describe("network.ts — state file", () => {
       saveState(a, { cwd });
       saveState(b, { cwd });
       expect(loadState({ cwd })).toEqual(b);
+    });
+
+    it("writes the state file owner-only (0600) since it holds wallet secrets", () => {
+      if (process.platform === "win32") return; // POSIX modes don't apply
+      const cwd = tmpCwd();
+      saveState(
+        {
+          version: STATE_VERSION,
+          activeNetwork: "preview",
+          wallets: {},
+          deployments: {},
+        },
+        { cwd },
+      );
+      const mode = fs.statSync(path.join(cwd, STATE_FILE_NAME)).mode & 0o777;
+      expect(mode).toBe(0o600);
     });
 
     it("formats output with 2-space indent (human-readable)", () => {
@@ -258,9 +282,6 @@ describe("network.ts — state file", () => {
   });
 
   describe("getOrCreateSeed", () => {
-    const GENESIS_SEED =
-      "0000000000000000000000000000000000000000000000000000000000000001";
-
     it("returns the hardcoded genesis seed for undeployed", () => {
       const cwd = tmpCwd();
       expect(getOrCreateSeed("undeployed", { env: {}, cwd })).toBe(
@@ -276,12 +297,43 @@ describe("network.ts — state file", () => {
 
     it("uses MIDNIGHT_WALLET_SEED env var when set, no state write", () => {
       const cwd = tmpCwd();
+      const envSeed = "ab".repeat(32); // 64 hex chars = 32 bytes
       const seed = getOrCreateSeed("preview", {
-        env: { MIDNIGHT_WALLET_SEED: "0xfromEnv" },
+        env: { MIDNIGHT_WALLET_SEED: envSeed },
         cwd,
       });
-      expect(seed).toBe("0xfromEnv");
+      expect(seed).toBe(envSeed);
       expect(fs.existsSync(path.join(cwd, STATE_FILE_NAME))).toBe(false);
+    });
+
+    it("strips an optional 0x prefix from MIDNIGHT_WALLET_SEED", () => {
+      const cwd = tmpCwd();
+      const seed = getOrCreateSeed("preview", {
+        env: { MIDNIGHT_WALLET_SEED: `0x${"cd".repeat(32)}` },
+        cwd,
+      });
+      expect(seed).toBe("cd".repeat(32));
+    });
+
+    it("trims surrounding whitespace/newlines from MIDNIGHT_WALLET_SEED", () => {
+      const cwd = tmpCwd();
+      const seed = getOrCreateSeed("preview", {
+        env: { MIDNIGHT_WALLET_SEED: `  ${"ef".repeat(32)}\n` },
+        cwd,
+      });
+      expect(seed).toBe("ef".repeat(32));
+    });
+
+    it.each([
+      ["non-hex", "not-a-seed"],
+      ["odd length", "abc"],
+      ["too short (below 16 bytes)", "ab".repeat(15)],
+      ["too long (above 64 bytes)", "ab".repeat(65)],
+    ])("rejects MIDNIGHT_WALLET_SEED with %s", (_label, bad) => {
+      const cwd = tmpCwd();
+      expect(() =>
+        getOrCreateSeed("preview", { env: { MIDNIGHT_WALLET_SEED: bad }, cwd }),
+      ).toThrow(/MIDNIGHT_WALLET_SEED/);
     });
 
     it("returns persisted seed for non-undeployed when state file has one", () => {
@@ -303,12 +355,13 @@ describe("network.ts — state file", () => {
       expect(getOrCreateSeed("preview", { env: {}, cwd })).toBe("0xpersisted");
     });
 
-    it("generates and persists a 64-char hex seed when none exists for non-undeployed", () => {
+    it("generates and persists a 128-char BIP-39 seed + mnemonic when none exists for non-undeployed", () => {
       const cwd = tmpCwd();
       const seed = getOrCreateSeed("preview", { env: {}, cwd });
-      expect(seed).toMatch(/^[0-9a-f]{64}$/);
+      expect(seed).toMatch(/^[0-9a-f]{128}$/);
       const state = loadState({ cwd });
       expect(state?.wallets?.preview?.seed).toBe(seed);
+      expect(state?.wallets?.preview?.mnemonic?.split(" ")).toHaveLength(24);
       expect(state?.activeNetwork).toBe("preview");
     });
 
@@ -330,6 +383,142 @@ describe("network.ts — state file", () => {
       expect(state?.wallets?.preview?.seed).toBe("0xexisting");
       expect(state?.deployments?.preview?.address).toBe("a");
       expect(state?.wallets?.preprod?.seed).toBe(seed);
+    });
+  });
+
+  describe("mnemonic-first wallet (BIP-39)", () => {
+    // Canonical BIP-39 vector: all-zero entropy, empty passphrase. The
+    // expected seed locks derivation to standard mnemonicToSeed — if anyone
+    // swaps in mnemonicToEntropy (which "works" but breaks Lace parity),
+    // this fails.
+    const VECTOR_MNEMONIC =
+      "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    const VECTOR_SEED =
+      "5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc19a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d48b2d2ce9e38e4";
+
+    it("derives the canonical BIP-39 seed for the standard test vector", () => {
+      expect(mnemonicToSeedHex(VECTOR_MNEMONIC)).toBe(VECTOR_SEED);
+    });
+
+    it("matches an independent PBKDF2-HMAC-SHA512 derivation", () => {
+      const independent = pbkdf2Sync(
+        VECTOR_MNEMONIC.normalize("NFKD"),
+        "mnemonic",
+        2048,
+        64,
+        "sha512",
+      ).toString("hex");
+      expect(mnemonicToSeedHex(VECTOR_MNEMONIC)).toBe(independent);
+    });
+
+    it("normalizes whitespace and case before validation and derivation", () => {
+      const messy = `  ${VECTOR_MNEMONIC.toUpperCase().replace(/ /g, "   ")}  `;
+      expect(normalizeMnemonic(messy)).toBe(VECTOR_MNEMONIC);
+      expect(isValidMnemonic(messy)).toBe(true);
+      expect(mnemonicToSeedHex(messy)).toBe(VECTOR_SEED);
+    });
+
+    it("generates 24-word phrases that validate and derive 128-char seeds", () => {
+      const phrase = generateMnemonicPhrase();
+      expect(phrase.split(" ")).toHaveLength(24);
+      expect(isValidMnemonic(phrase)).toBe(true);
+      expect(mnemonicToSeedHex(phrase)).toMatch(/^[0-9a-f]{128}$/);
+      expect(generateMnemonicPhrase()).not.toBe(phrase);
+    });
+
+    it("rejects tampered phrases via the checksum", () => {
+      expect(
+        isValidMnemonic(VECTOR_MNEMONIC.replace(/about$/, "abandon")),
+      ).toBe(false);
+      expect(
+        isValidMnemonic(
+          `zebra ${VECTOR_MNEMONIC.split(" ").slice(1).join(" ")}`,
+        ),
+      ).toBe(false);
+    });
+
+    it("getOrCreateWallet returns genesis for undeployed without creating", () => {
+      const cwd = tmpCwd();
+      const w = getOrCreateWallet("undeployed", { env: {}, cwd });
+      expect(w).toEqual({ seed: GENESIS_SEED, mnemonic: null, created: false });
+      expect(fs.existsSync(path.join(cwd, STATE_FILE_NAME))).toBe(false);
+    });
+
+    it("getOrCreateWallet generates once, then restores with created=false", () => {
+      const cwd = tmpCwd();
+      const first = getOrCreateWallet("preview", { env: {}, cwd });
+      expect(first.created).toBe(true);
+      expect(first.mnemonic?.split(" ")).toHaveLength(24);
+      expect(first.seed).toBe(mnemonicToSeedHex(first.mnemonic as string));
+      const again = getOrCreateWallet("preview", { env: {}, cwd });
+      expect(again).toEqual({ ...first, created: false });
+    });
+
+    it("passes legacy pre-mnemonic wallets through untouched", () => {
+      const cwd = tmpCwd();
+      const legacySeed = "12".repeat(32);
+      saveState(
+        {
+          version: STATE_VERSION,
+          activeNetwork: "preview",
+          wallets: { preview: { seed: legacySeed, createdAt: "x" } },
+          deployments: {},
+        },
+        { cwd },
+      );
+      const w = getOrCreateWallet("preview", { env: {}, cwd });
+      expect(w).toEqual({ seed: legacySeed, mnemonic: null, created: false });
+      expect(loadState({ cwd })?.wallets?.preview).toEqual({
+        seed: legacySeed,
+        createdAt: "x",
+      });
+    });
+
+    it("uses MIDNIGHT_WALLET_MNEMONIC: derived seed, not persisted", () => {
+      const cwd = tmpCwd();
+      const w = getOrCreateWallet("preprod", {
+        env: { MIDNIGHT_WALLET_MNEMONIC: VECTOR_MNEMONIC },
+        cwd,
+      });
+      expect(w).toEqual({
+        seed: VECTOR_SEED,
+        mnemonic: VECTOR_MNEMONIC,
+        created: false,
+      });
+      expect(fs.existsSync(path.join(cwd, STATE_FILE_NAME))).toBe(false);
+    });
+
+    it("rejects an invalid MIDNIGHT_WALLET_MNEMONIC", () => {
+      const cwd = tmpCwd();
+      expect(() =>
+        getOrCreateWallet("preview", {
+          env: { MIDNIGHT_WALLET_MNEMONIC: "definitely not a phrase" },
+          cwd,
+        }),
+      ).toThrow(/MIDNIGHT_WALLET_MNEMONIC/);
+    });
+
+    it("rejects setting both MIDNIGHT_WALLET_SEED and MIDNIGHT_WALLET_MNEMONIC", () => {
+      const cwd = tmpCwd();
+      expect(() =>
+        getOrCreateWallet("preview", {
+          env: {
+            MIDNIGHT_WALLET_SEED: "ab".repeat(32),
+            MIDNIGHT_WALLET_MNEMONIC: VECTOR_MNEMONIC,
+          },
+          cwd,
+        }),
+      ).toThrow(/unset one/i);
+    });
+
+    it("formatWalletBackupNotice prints only for freshly created wallets", () => {
+      const cwd = tmpCwd();
+      const created = getOrCreateWallet("preview", { env: {}, cwd });
+      const notice = formatWalletBackupNotice(created, "preview");
+      expect(notice).toContain(created.mnemonic as string);
+      expect(notice).toContain("recovery phrase");
+      const restored = getOrCreateWallet("preview", { env: {}, cwd });
+      expect(formatWalletBackupNotice(restored, "preview")).toBeNull();
     });
   });
 
@@ -509,6 +698,6 @@ describe("network.ts CLI", { timeout: 30_000 }, () => {
     runCli(cwd, "preprod");
     const state = loadState({ cwd });
     expect(state?.activeNetwork).toBe("preprod");
-    expect(state?.wallets?.preview?.seed).toMatch(/^[0-9a-f]{64}$/);
+    expect(state?.wallets?.preview?.seed).toMatch(/^[0-9a-f]{128}$/);
   });
 });

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -21,7 +21,7 @@ export function enableDebug() {
   debugEnabled = true;
 }
 
-export function debug(message: string, data?: any) {
+export function debug(message: string, data?: unknown) {
   if (!debugEnabled) return;
 
   console.log(chalk.gray("[debug]"), message);

--- a/src/utils/template-manager.ts
+++ b/src/utils/template-manager.ts
@@ -46,7 +46,7 @@ export class TemplateManager {
   private async copyTemplate(
     templatePath: string,
     projectPath: string,
-    templateVars: Record<string, any>,
+    templateVars: Record<string, string | number>,
   ): Promise<void> {
     const files = await fs.readdir(templatePath, { withFileTypes: true });
 

--- a/templates/hello-world/README.md.template
+++ b/templates/hello-world/README.md.template
@@ -78,12 +78,33 @@ npm run network undeployed      # switch back to local devnet
 ### How wallets work across networks
 
 - `undeployed` uses a hardcoded genesis seed. Local devnet pre-funds it.
-- `preview` and `preprod` generate a fresh seed on first use and store it
-  in `.midnight-state.json` (gitignored). The seed survives switching
+- `preview` and `preprod` generate a fresh wallet on first use: a 24-word
+  BIP-39 recovery phrase (printed once) plus its derived seed, both stored
+  in `.midnight-state.json` (gitignored). The wallet survives switching
   networks — switch back later and your funded wallet returns.
-- **Back up your seed** if you fund a public-network wallet you care
-  about. Open `.midnight-state.json` and copy the relevant
-  `wallets.<network>.seed` value to a safe place.
+- **Back up your recovery phrase** if you fund a public-network wallet you
+  care about. It is printed when the wallet is created and kept in
+  `.midnight-state.json` under `wallets.<network>.mnemonic`. Anyone holding
+  the phrase controls the wallet.
+- Wallets created before mnemonic support keep working from their stored
+  `seed`; they just have no phrase to import into Lace.
+
+### Using the same wallet as Lace
+
+Seeds are derived with the standard BIP-39 `mnemonicToSeed` step — the same
+convention Lace uses — so identity is portable in both directions:
+
+- **Bring your Lace wallet here**: pass your recovery phrase via the
+  `MIDNIGHT_WALLET_MNEMONIC` env var — the derived addresses match Lace.
+  To keep the phrase out of your shell history, enter it with a hidden
+  prompt instead of typing it inline:
+
+  ```bash
+  read -s MIDNIGHT_WALLET_MNEMONIC && export MIDNIGHT_WALLET_MNEMONIC
+  npm run deploy
+  ```
+- **Take a scaffold wallet to Lace**: restore Lace from the 24-word phrase
+  in `.midnight-state.json`.
 
 ### Funding a public-network wallet
 
@@ -106,7 +127,8 @@ suffix — they apply to whichever network is active for the run):
 
 | Variable | Effect |
 |---|---|
-| `MIDNIGHT_WALLET_SEED` | Use this seed instead of generating/persisting one. Useful for CI with a pre-funded wallet. |
+| `MIDNIGHT_WALLET_SEED` | Use this hex seed (32-128 hex chars; a Lace-compatible BIP-39 seed is 128) instead of generating/persisting one. Useful for CI with a pre-funded wallet. |
+| `MIDNIGHT_WALLET_MNEMONIC` | Use this BIP-39 recovery phrase instead of generating a wallet — e.g. your Lace phrase, for the same addresses as Lace. Not persisted. Set only one of seed/mnemonic. |
 | `MIDNIGHT_INDEXER_URL` | Override the indexer GraphQL URL. |
 | `MIDNIGHT_INDEXER_WS_URL` | Override the indexer WS URL. |
 | `MIDNIGHT_NODE_URL` | Override the node RPC URL. |

--- a/templates/hello-world/package.json.template
+++ b/templates/hello-world/package.json.template
@@ -31,6 +31,7 @@
     "@midnight-ntwrk/midnight-js-types": "4.1.1",
     "@midnight-ntwrk/midnight-js-utils": "4.1.1",
     "@midnight-ntwrk/wallet-sdk": "1.2.0",
+    "@scure/bip39": "2.2.0",
     "rxjs": "^7.8.2",
     "ws": "^8.21.1"
   },

--- a/templates/hello-world/scripts/e2e-check.ts.template
+++ b/templates/hello-world/scripts/e2e-check.ts.template
@@ -14,7 +14,7 @@ import { httpClientProofProvider } from '@midnight-ntwrk/midnight-js-http-client
 import { indexerPublicDataProvider } from '@midnight-ntwrk/midnight-js-indexer-public-data-provider';
 import { levelPrivateStateProvider } from '@midnight-ntwrk/midnight-js-level-private-state-provider';
 import { NodeZkConfigProvider } from '@midnight-ntwrk/midnight-js-node-zk-config-provider';
-import { resolveNetwork, getOrCreateSeed, getDeployment } from '../src/network';
+import { resolveNetwork, getOrCreateWallet, formatWalletBackupNotice, getDeployment } from '../src/network';
 import { createWallet, persistWalletState } from '../src/wallet';
 import { CompiledContract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
 
@@ -27,7 +27,12 @@ const PRIVATE_STATE_ID = 'helloWorldPrivateState';
 // ─── Network configuration ─────────────────────────────────────────────────────
 
 const { network, config: networkConfig } = resolveNetwork();
-const SEED = getOrCreateSeed(network);
+const WALLET = getOrCreateWallet(network);
+const SEED = WALLET.seed;
+{
+  const notice = formatWalletBackupNotice(WALLET, network);
+  if (notice) console.log(notice);
+}
 
 function fail(msg: string): never {
   console.error(`❌ e2e-check failed: ${msg}`);

--- a/templates/hello-world/src/check-balance.ts.template
+++ b/templates/hello-world/src/check-balance.ts.template
@@ -4,7 +4,7 @@
 import { WebSocket } from 'ws';
 
 // Midnight SDK imports
-import { resolveNetwork, getOrCreateSeed } from './network';
+import { resolveNetwork, getOrCreateWallet, formatWalletBackupNotice } from './network';
 // unshieldedToken is re-exported from ./wallet (originally @midnight-ntwrk/midnight-js-protocol/ledger).
 import { createWallet, persistWalletState, unshieldedToken } from './wallet';
 
@@ -15,7 +15,12 @@ globalThis.WebSocket = WebSocket;
 // ─── Network configuration ─────────────────────────────────────────────────────
 
 const { network, config: networkConfig } = resolveNetwork();
-const SEED = getOrCreateSeed(network);
+const WALLET = getOrCreateWallet(network);
+const SEED = WALLET.seed;
+{
+  const notice = formatWalletBackupNotice(WALLET, network);
+  if (notice) console.log(notice);
+}
 
 // ─── Main ──────────────────────────────────────────────────────────────────────
 

--- a/templates/hello-world/src/cli.ts.template
+++ b/templates/hello-world/src/cli.ts.template
@@ -15,7 +15,7 @@ import { httpClientProofProvider } from '@midnight-ntwrk/midnight-js-http-client
 import { indexerPublicDataProvider } from '@midnight-ntwrk/midnight-js-indexer-public-data-provider';
 import { levelPrivateStateProvider } from '@midnight-ntwrk/midnight-js-level-private-state-provider';
 import { NodeZkConfigProvider } from '@midnight-ntwrk/midnight-js-node-zk-config-provider';
-import { resolveNetwork, getOrCreateSeed, getDeployment } from './network';
+import { resolveNetwork, getOrCreateWallet, formatWalletBackupNotice, getDeployment } from './network';
 import { createWallet, persistWalletState, unshieldedToken, type WalletContext } from './wallet';
 import { CompiledContract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
 
@@ -28,7 +28,12 @@ globalThis.WebSocket = WebSocket;
 const PRIVATE_STATE_ID = 'helloWorldPrivateState';
 
 const { network, config: networkConfig } = resolveNetwork();
-const SEED = getOrCreateSeed(network);
+const WALLET = getOrCreateWallet(network);
+const SEED = WALLET.seed;
+{
+  const notice = formatWalletBackupNotice(WALLET, network);
+  if (notice) console.log(notice);
+}
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const zkConfigPath = path.resolve(__dirname, '..', 'contracts', 'managed', 'hello-world');

--- a/templates/hello-world/src/deploy.ts.template
+++ b/templates/hello-world/src/deploy.ts.template
@@ -6,7 +6,7 @@
  */
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { resolveNetwork, getOrCreateSeed, recordDeployment } from './network';
+import { resolveNetwork, getOrCreateWallet, formatWalletBackupNotice, recordDeployment } from './network';
 import { createWallet, persistWalletState, unshieldedToken, type WalletContext } from './wallet';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { WebSocket } from 'ws';
@@ -33,7 +33,12 @@ const PRIVATE_STATE_ID = 'helloWorldPrivateState';
 // 'undeployed' (local devnet). Switch networks with: npm run network <name>
 
 const { network, config: networkConfig } = resolveNetwork();
-const SEED = getOrCreateSeed(network);
+const WALLET = getOrCreateWallet(network);
+const SEED = WALLET.seed;
+{
+  const notice = formatWalletBackupNotice(WALLET, network);
+  if (notice) console.log(notice);
+}
 
 // ─── Proof server readiness ────────────────────────────────────────────────────
 //

--- a/templates/hello-world/src/network.ts
+++ b/templates/hello-world/src/network.ts
@@ -5,8 +5,11 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import * as crypto from 'node:crypto';
+import { Buffer } from 'node:buffer';
 import { fileURLToPath } from 'node:url';
+
+import { generateMnemonic, mnemonicToSeedSync, validateMnemonic } from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english.js';
 
 export type NetworkId = 'undeployed' | 'preview' | 'preprod';
 
@@ -28,10 +31,17 @@ export interface DeploymentRecord {
   deployer: string;
 }
 
+export interface WalletRecord {
+  seed: string;
+  /** BIP-39 recovery phrase. Absent on wallets created before mnemonic support. */
+  mnemonic?: string;
+  createdAt: string;
+}
+
 export interface NetworkState {
   version: 1;
   activeNetwork: NetworkId;
-  wallets: Partial<Record<NetworkId, { seed: string; createdAt: string }>>;
+  wallets: Partial<Record<NetworkId, WalletRecord>>;
   deployments: Partial<Record<NetworkId, DeploymentRecord>>;
 }
 
@@ -109,9 +119,10 @@ export function loadState(opts: FsOptions = {}): NetworkState | null {
 
 export function saveState(state: NetworkState, opts: FsOptions = {}): void {
   const p = statePath(opts);
-  // Write to a sibling tmp file then rename → atomic on POSIX.
+  // Write to a sibling tmp file then rename → atomic on POSIX. Owner-only
+  // mode: the file holds wallet secrets (seed + recovery phrase).
   const tmp = `${p}.tmp-${process.pid}-${Date.now()}`;
-  fs.writeFileSync(tmp, `${JSON.stringify(state, null, 2)}\n`);
+  fs.writeFileSync(tmp, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
   fs.renameSync(tmp, p);
 }
 
@@ -197,25 +208,98 @@ export function resolveNetwork(opts: ResolveOptions = {}): ResolveResult {
 
 export const GENESIS_SEED = '0000000000000000000000000000000000000000000000000000000000000001';
 
+// ─── Wallet identity (BIP-39, Lace-compatible) ─────────────────────────────────
+//
+// Public-network wallets are mnemonic-first: a 24-word BIP-39 phrase whose
+// seed is derived with the standard mnemonicToSeed PBKDF2 step (empty
+// passphrase). Lace derives seeds the same way, so a phrase generated here
+// restores the identical wallet in Lace and vice versa.
+//
+// IMPORTANT: derivation must stay mnemonicToSeed (64-byte seed). Do NOT
+// switch to mnemonicToEntropy — it also "works" but derives a different
+// wallet from the same words, silently breaking Lace compatibility.
+
+export function normalizeMnemonic(mnemonic: string): string {
+  return mnemonic.trim().toLowerCase().split(/\s+/).join(' ');
+}
+
+/** Generate a new 24-word BIP-39 recovery phrase (256-bit entropy). */
+export function generateMnemonicPhrase(): string {
+  return generateMnemonic(wordlist, 256);
+}
+
+export function isValidMnemonic(mnemonic: string): boolean {
+  return validateMnemonic(normalizeMnemonic(mnemonic), wordlist);
+}
+
+/** Standard BIP-39 seed for a phrase: 64 bytes, returned as 128 hex chars. */
+export function mnemonicToSeedHex(mnemonic: string): string {
+  return Buffer.from(mnemonicToSeedSync(normalizeMnemonic(mnemonic))).toString('hex');
+}
+
+// BIP-32 master seeds must be 16-64 whole bytes → 32-128 hex chars in even
+// steps. Validating up front matters because Buffer.from(s, 'hex') silently
+// stops at the first invalid character, which would derive the wrong wallet
+// from a truncated paste instead of failing.
+const SEED_HEX_RE = /^(?:[0-9a-fA-F]{2}){16,64}$/;
+
 export interface SeedOptions {
   env?: NodeJS.ProcessEnv;
   cwd?: string;
 }
 
-export function getOrCreateSeed(network: NetworkId, opts: SeedOptions = {}): string {
+export interface WalletCredentials {
+  seed: string;
+  /** BIP-39 phrase when known; null for genesis, env-seed, and legacy wallets. */
+  mnemonic: string | null;
+  /** True when this call generated (and persisted) a brand-new wallet. */
+  created: boolean;
+}
+
+export function getOrCreateWallet(network: NetworkId, opts: SeedOptions = {}): WalletCredentials {
   const env = opts.env ?? process.env;
   const cwd = opts.cwd ?? process.cwd();
 
-  if (network === 'undeployed') return GENESIS_SEED;
+  if (network === 'undeployed') return { seed: GENESIS_SEED, mnemonic: null, created: false };
 
-  const fromEnv = env.MIDNIGHT_WALLET_SEED;
-  if (fromEnv) return fromEnv;
+  const envSeed = env.MIDNIGHT_WALLET_SEED;
+  const envMnemonic = env.MIDNIGHT_WALLET_MNEMONIC;
+  if (envSeed && envMnemonic) {
+    throw new Error(
+      'Both MIDNIGHT_WALLET_SEED and MIDNIGHT_WALLET_MNEMONIC are set — unset one; they would select different wallets.',
+    );
+  }
+  if (envSeed) {
+    // Trim first: secrets pasted into env vars commonly carry stray whitespace
+    // or a trailing newline, which the pre-validation code tolerated.
+    const trimmed = envSeed.trim();
+    const hex = trimmed.startsWith('0x') || trimmed.startsWith('0X') ? trimmed.slice(2) : trimmed;
+    if (!SEED_HEX_RE.test(hex)) {
+      throw new Error(
+        'MIDNIGHT_WALLET_SEED must be 32-128 hex characters (16-64 whole bytes). ' +
+          'A Lace-compatible BIP-39 seed is 128 hex characters — or set MIDNIGHT_WALLET_MNEMONIC to pass the phrase directly.',
+      );
+    }
+    return { seed: hex, mnemonic: null, created: false };
+  }
+  if (envMnemonic) {
+    if (!isValidMnemonic(envMnemonic)) {
+      throw new Error(
+        'MIDNIGHT_WALLET_MNEMONIC is not a valid BIP-39 recovery phrase (check the words and word count).',
+      );
+    }
+    return { seed: mnemonicToSeedHex(envMnemonic), mnemonic: normalizeMnemonic(envMnemonic), created: false };
+  }
 
   const existing = loadState({ cwd });
-  const persisted = existing?.wallets?.[network]?.seed;
-  if (persisted) return persisted;
+  const persisted = existing?.wallets?.[network];
+  if (persisted?.seed) {
+    // Legacy pre-mnemonic wallets have no phrase; their seed passes through untouched.
+    return { seed: persisted.seed, mnemonic: persisted.mnemonic ?? null, created: false };
+  }
 
-  const seed = crypto.randomBytes(32).toString('hex');
+  const mnemonic = generateMnemonicPhrase();
+  const seed = mnemonicToSeedHex(mnemonic);
   const next: NetworkState = existing ?? {
     version: STATE_VERSION,
     activeNetwork: network,
@@ -225,10 +309,36 @@ export function getOrCreateSeed(network: NetworkId, opts: SeedOptions = {}): str
   next.activeNetwork = network;
   next.wallets = {
     ...next.wallets,
-    [network]: { seed, createdAt: new Date().toISOString() },
+    [network]: { seed, mnemonic, createdAt: new Date().toISOString() },
   };
   saveState(next, { cwd });
-  return seed;
+  return { seed, mnemonic, created: true };
+}
+
+/** Back-compat wrapper returning only the seed. Prefer getOrCreateWallet. */
+export function getOrCreateSeed(network: NetworkId, opts: SeedOptions = {}): string {
+  return getOrCreateWallet(network, opts).seed;
+}
+
+/**
+ * One-time backup notice for a freshly generated wallet; null otherwise.
+ * Callers print this right after obtaining credentials.
+ */
+export function formatWalletBackupNotice(
+  wallet: WalletCredentials,
+  network: NetworkId,
+): string | null {
+  if (!wallet.created || !wallet.mnemonic) return null;
+  return [
+    '',
+    `  New ${network} wallet generated. Its 24-word recovery phrase:`,
+    '',
+    `    ${wallet.mnemonic}`,
+    '',
+    '  Write this phrase down — anyone holding it controls the wallet. It also',
+    `  restores the same wallet in Lace, and is saved to ${STATE_FILE_NAME} (gitignored).`,
+    '',
+  ].join('\n');
 }
 
 export function getDeployment(network: NetworkId, opts: FsOptions = {}): DeploymentRecord | null {


### PR DESCRIPTION
Closes #37

The hello-world template created public-network wallets from 32 raw random bytes (`crypto.randomBytes(32)`) with no BIP-39 mnemonic. A wallet created by the scaffold could never be imported into Lace, and a Lace user couldn't bring their wallet to a scaffolded project the "same mnemonic, different address" reports in #37.

### Fix

Public-network wallets are now **mnemonic-first**: a 24-word BIP-39 phrase whose seed is derived with the standard `mnemonicToSeed` PBKDF2 step (empty passphrase) verified to be the exact convention Lace uses, over the identical derivation path (`m/44'/2400'/0'/{role}/0`). Identity is portable in both directions.

- `network.ts`: mnemonic helpers via `@scure/bip39` (pinned 2.2.0, dep-of-a-dep already via wallet-sdk), `getOrCreateWallet` (old `getOrCreateSeed` kept as a compatible wrapper), `MIDNIGHT_WALLET_MNEMONIC` env support, `MIDNIGHT_WALLET_SEED` validation (16–64-byte hex, `0x` stripped, whitespace trimmed), state file written `0600`
- deploy / cli / check-balance / e2e-check print a one-time recovery-phrase backup notice on wallet creation
- Legacy 32-byte-seed wallets pass through untouched; devnet keeps the genesis seed; existing scaffolded projects unaffected
- README: backup guidance + "Using the same wallet as Lace" (with a shell-history-safe `read -s` recipe)
- A canonical BIP-39 test vector locks derivation to `mnemonicToSeed` — guarding against the `mnemonicToEntropy` convention that also "works" but silently derives a different wallet from the same words (the two conventions genuinely coexist in the ecosystem today)

Also fixes the broken `test:smoke` script (pointed at `dist/test.js`, which the tsc build deliberately never emits; now runs via `tsx`) and the last two `no-explicit-any` lint warnings.

## Verification

- 109/109 unit tests, including the BIP-39 canonical vector + an independent PBKDF2 cross-check
- Scaffolded a real project: renders, installs, strict `tsc --noEmit` passes
- 14/14 runtime parity checks in the scaffolded app — **byte-identical role keys** between the scaffold-seed path and the Lace `mnemonicToSeed` path through the actual wallet-sdk
- Full local devnet E2E: compose up → compile → deploy succeeded (genesis path untouched)
- `test:smoke` runs green end-to-end; `eslint src/` reports zero problems