### PR TITLE
chore(ci): pin npm to 12.0.2 and add supply-chain cooldown

### DIFF
--- a/.github/workflows/_e2e-job.yml
+++ b/.github/workflows/_e2e-job.yml
@@ -41,6 +41,9 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
+      - name: Update NPM
+        run: npm install -g npm@12.0.2
+
       - name: Install Docker via Colima (macOS only)
         if: runner.os == 'macOS'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
 
+      - name: Update NPM
+        run: npm install -g npm@12.0.2
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,9 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Update NPM
+        run: npm install -g npm@12.0.2
+
       - run: npm ci
       - run: npm run build
       - run: npm run test

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# Supply-chain cooldown: refuse dependency versions published <7 days ago (npm 12+).
+# Own packages are exempt so same-day @midnight-ntwrk releases stay installable.
+min-release-age=7
+min-release-age-exclude[]=@midnight-ntwrk/*
+min-release-age-exclude[]=@midnightntwrk/*


### PR DESCRIPTION
Supply-chain hardening following the 2026-08-04 keyv/cacheable npm worm (868+ packages compromised via `preinstall` payloads published through legitimate maintainer accounts).

- Pin the npm CLI to 12.0.2 in CI (npm 12 blocks dependency lifecycle scripts by default behind `allowScripts`) instead of floating `npm@latest`/setup-node default
- Bump `node-version` where npm 12 requires it (engines: `^22.22.2 || ^24.15.0 || >=26`)
- Add `.npmrc` cooldown: `min-release-age=7` so freshly-published (potentially wormed) versions can't resolve for 7 days; `@midnight-ntwrk/*` and `@midnightntwrk/*` exempt so same-day internal releases still install
- Renovate: npm CLI pins in workflows/Earthfiles are matched by new custom managers in `midnightntwrk/renovate-config`, so this pin stays bumpable automatically
