### PR TITLE
fix(security): validate repo/branch inputs in GitCloner to prevent injection

### DIFF
--- a/src/__tests__/git-cloner.test.ts
+++ b/src/__tests__/git-cloner.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { spawnSync } from "child_process";
+import { GitCloner } from "../utils/git-cloner";
+
+vi.mock("child_process", () => ({
+  spawnSync: vi.fn(),
+}));
+
+const mockSpawnSync = spawnSync as ReturnType<typeof vi.fn>;
+
+function gitOk() {
+  // First call: `git --version` check; second call: the clone itself.
+  mockSpawnSync
+    .mockReturnValueOnce({ status: 0 })
+    .mockReturnValueOnce({ status: 0 });
+}
+
+describe("GitCloner.clone", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes an argument array (no shell) with -- before positional args", async () => {
+    gitOk();
+    await GitCloner.clone("owner/repo", "/tmp/target");
+    expect(mockSpawnSync).toHaveBeenLastCalledWith(
+      "git",
+      [
+        "clone",
+        "--depth",
+        "1",
+        "--branch",
+        "main",
+        "--",
+        "https://github.com/owner/repo.git",
+        "/tmp/target",
+      ],
+      { stdio: "pipe" },
+    );
+  });
+
+  it("accepts realistic branch names", async () => {
+    for (const branch of ["main", "release/v1.0", "v1.2.3", "feat_x-y.z"]) {
+      vi.clearAllMocks();
+      gitOk();
+      await expect(
+        GitCloner.clone("owner/repo", "/tmp/target", branch),
+      ).resolves.toBeUndefined();
+    }
+  });
+
+  it.each([
+    ["option injection via --upload-pack", "--upload-pack=touch /tmp/pwned"],
+    ["leading dash", "-x"],
+    ["whitespace", "main; rm -rf /"],
+    ["shell metacharacters", "$(reboot)"],
+    ["backticks", "`reboot`"],
+    ["double dots", "a..b"],
+    ["empty string", ""],
+  ])("rejects branch with %s", async (_label, branch) => {
+    await expect(
+      GitCloner.clone("owner/repo", "/tmp/target", branch),
+    ).rejects.toThrow(/Invalid branch name/);
+    // Rejected before any process is spawned — no retries burned either.
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["missing owner", "repo-only"],
+    ["extra path segment", "a/b/c"],
+    ["full URL", "https://github.com/a/b"],
+    ["whitespace smuggling", "owner/repo extra"],
+    ["shell metacharacters", "owner/$(reboot)"],
+    ["option-like owner", "--config=x/y"],
+  ])("rejects repo with %s", async (_label, repo) => {
+    await expect(GitCloner.clone(repo, "/tmp/target")).rejects.toThrow(
+      /Invalid repository/,
+    );
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+  });
+
+  it("throws a clear error when git is not installed", async () => {
+    mockSpawnSync.mockReturnValueOnce({ status: 1 });
+    await expect(GitCloner.clone("owner/repo", "/tmp/target")).rejects.toThrow(
+      /Git is not installed/,
+    );
+  });
+
+  it("retries failed clones and surfaces the final error", async () => {
+    mockSpawnSync.mockImplementation((_cmd: string, args: string[]) =>
+      args[0] === "--version"
+        ? { status: 0 }
+        : { status: 128, stderr: Buffer.from("fatal: repository not found") },
+    );
+    await expect(
+      GitCloner.clone("owner/missing", "/tmp/target", "main", 2),
+    ).rejects.toThrow(/after 2 attempts/);
+    // 1 version check + 2 clone attempts
+    const cloneCalls = mockSpawnSync.mock.calls.filter(
+      (c) => c[1][0] === "clone",
+    );
+    expect(cloneCalls).toHaveLength(2);
+  });
+});
+
+describe("GitCloner.isGitAvailable", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reflects the git --version exit status", () => {
+    mockSpawnSync.mockReturnValueOnce({ status: 0 });
+    expect(GitCloner.isGitAvailable()).toBe(true);
+    mockSpawnSync.mockReturnValueOnce({ status: 127 });
+    expect(GitCloner.isGitAvailable()).toBe(false);
+  });
+});

--- a/src/utils/git-cloner.ts
+++ b/src/utils/git-cloner.ts
@@ -18,6 +18,16 @@ import fs from "fs-extra";
 import path from "path";
 import { debug } from "./debug.js";
 
+// GitHub owner/name shape. Also blocks values that could smuggle extra
+// arguments or URL segments into the git invocation.
+const REPO_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+
+// Conservative subset of valid git ref names. The leading alphanumeric
+// matters: spawnSync passes args without a shell, but git itself would
+// still honor a branch like "--upload-pack=<cmd>" as an option — argument
+// injection rather than shell injection.
+const BRANCH_RE = /^[A-Za-z0-9][A-Za-z0-9._/-]*$/;
+
 export class GitCloner {
   /**
    * Clone a GitHub repository with retry logic
@@ -28,6 +38,19 @@ export class GitCloner {
     branch: string = "main",
     retries: number = 3,
   ): Promise<void> {
+    // Validate before anything else — bad input should fail immediately,
+    // not burn retries.
+    if (!REPO_RE.test(repo)) {
+      throw new Error(
+        `Invalid repository "${repo}". Expected format: owner/repo`,
+      );
+    }
+    if (!BRANCH_RE.test(branch) || branch.includes("..")) {
+      throw new Error(
+        `Invalid branch name "${branch}". Branch names must start with a letter or digit and may only contain letters, digits, ".", "_", "/" and "-".`,
+      );
+    }
+
     const repoUrl = `https://github.com/${repo}.git`;
 
     const gitCheck = spawnSync("git", ["--version"], { stdio: "ignore" });
@@ -46,9 +69,20 @@ export class GitCloner {
           await fs.remove(targetPath);
         }
 
+        // "--" terminates option parsing so the positional args can never
+        // be interpreted as git options.
         const result = spawnSync(
           "git",
-          ["clone", "--depth", "1", "--branch", branch, repoUrl, targetPath],
+          [
+            "clone",
+            "--depth",
+            "1",
+            "--branch",
+            branch,
+            "--",
+            repoUrl,
+            targetPath,
+          ],
           { stdio: "pipe" },
         );
         if (result.status !== 0) {


### PR DESCRIPTION
### Problem

`GitCloner.clone` interpolates the `repo` and `branch` parameters into the git invocation. Both are user-controllable via the `--from <owner/repo>` flag.

The clone already runs through `spawnSync` with an argument array (no shell), so classic shell-metacharacter injection (`;`, `$()`, backticks) was **not** reachable through the clone itself. But an unvalidated `branch` value could still be passed to git as an *option* rather than a ref e.g. `--upload-pack=<cmd>`, which git will execute. That's argument injection, and it's the real exposure the report points at.

### Fix

- Validate `repo` against `^owner/repo$` and `branch` against a conservative git-ref subset (must start with a letter/digit, no `..`) **before** the retry loop, so bad input fails immediately instead of burning retries.
- Add `--` before the positional `repoUrl`/`targetPath` args so they can never be reinterpreted as git options (defense in depth on top of the regexes).
- Keep `spawnSync` with an argument array, no shell, by construction.

The leading-alphanumeric rule on the branch regex is the load-bearing part: it rejects `--`-prefixed values that git would treat as options.

### Verification

- New `src/__tests__/git-cloner.test.ts`: option injection (`--upload-pack`, leading `-x`), shell metacharacters, `..`, empty/malformed values, and asserts the exact argument array (with `--`) reaches git. 127/127 suite green, lint clean, build clean.
- End-to-end: `create-mn-app --from midnightntwrk/create-mn-app` clones successfully; `--from 'owner/repo;touch /tmp/pwned'` is rejected and no file is created.