### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-mn-app",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-mn-app",
-      "version": "0.4.4",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-mn-app",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "Create Midnight Network applications with zero configuration",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Release **0.5.0** (minor — new user-facing feature since 0.4.4).

## Included since 0.4.4

- **feat**: mnemonic-first wallets (BIP-39, Lace parity) — `MIDNIGHT_WALLET_MNEMONIC`, one-time backup notice, `0600` state file (#100)
- **fix(security)**: `GitCloner` repo/branch input validation to prevent argument injection (#102)
- **fix(deps)**: brace-expansion and postcss advisories (#103)
- **chore**: repaired `test:smoke`, cleared remaining lint warnings (part of #100)

## Release mechanism

Merging this does **not** publish. Publishing is driven by [`publish.yml`](.github/workflows/publish.yml), which fires when a **GitHub Release** is created and runs `npm ci → build → test → npm publish` with the repo's `NPM_TOKEN` secret. After this merges, creating the `v0.5.0` release publishes to npm and triggers the post-publish E2E.

## Verification (at 0.5.0)

Lint clean, format clean, build clean, 127/127 tests. `npm publish --dry-run`: 78 files, 63.7 kB, scoped to `bin`/`dist`/`templates`/`package.json`/`README`/`LICENSE` — no stray secrets or `src/`.